### PR TITLE
Allow users to login via email

### DIFF
--- a/lib/alces/account/api.rb
+++ b/lib/alces/account/api.rb
@@ -32,7 +32,7 @@ require 'alces/account/errors'
 module Alces
   module Account
     class API
-      def login(username, password)
+      def login(username_or_email, password)
         sso_base_url = Config.sso_url.chomp('/')
 
         response = http.post(
@@ -42,7 +42,7 @@ module Alces
           },
           json: {
             account: {
-              username: username,
+              login: username_or_email,
               password: password
             }
           }

--- a/lib/alces/account/commands/account.rb
+++ b/lib/alces/account/commands/account.rb
@@ -179,9 +179,9 @@ module Alces
             prompt.warn "You are currently logged in to the Alces Flight platform as #{Paint[Config.username, :yellow, :bright]}."
             return
           end
-          username = if args[0].nil?
-                       prompt.say Paint["To sign in to your Alces Flight account please enter your username and\npassword.\n", '#2794d8']
-                       prompt.ask('Username:', default: Config.username)
+          username_or_email = if args[0].nil?
+                       prompt.say Paint["To sign in to your Alces Flight account please enter your username/email \nand password.\n", '#2794d8']
+                       prompt.ask('Username/Email:', default: Config.username)
                      else
                        prompt.say Paint["To sign in to your Alces Flight account please enter your password.\n", '#2794d8']
                        args[0]
@@ -194,14 +194,15 @@ module Alces
                        remove_after_stop: true,
                        append_newline: false,
                        status: Paint['Logging you in', '#2794d8']) do
-            login = api.login(username, password)
+            login = api.login(username_or_email, password)
           end
           token = login['authentication_token']
           email = login['email']
 
           Config.set(:sso_url, Config.sso_url)
           Config.set(:auth_token, token)
-          Config.set(:auth_user, username)
+          # TODO: Some how get the username associated with the email if required
+          Config.set(:auth_user, username_or_email)
           Config.set(:auth_email, email)
 
           prompt.say Paint["\nYou are now logged in to the Alces Flight plaform.", '#2794d8']

--- a/lib/alces/account/commands/account.rb
+++ b/lib/alces/account/commands/account.rb
@@ -198,11 +198,11 @@ module Alces
           end
           token = login['authentication_token']
           email = login['email']
+          username = login['username']
 
           Config.set(:sso_url, Config.sso_url)
           Config.set(:auth_token, token)
-          # TODO: Some how get the username associated with the email if required
-          Config.set(:auth_user, username_or_email)
+          Config.set(:auth_user, username)
           Config.set(:auth_email, email)
 
           prompt.say Paint["\nYou are now logged in to the Alces Flight plaform.", '#2794d8']

--- a/lib/alces/account/commands/account.rb
+++ b/lib/alces/account/commands/account.rb
@@ -180,12 +180,12 @@ module Alces
             return
           end
           username_or_email = if args[0].nil?
-                       prompt.say Paint["To sign in to your Alces Flight account please enter your username/email \nand password.\n", '#2794d8']
-                       prompt.ask('Username/Email:', default: Config.username)
-                     else
-                       prompt.say Paint["To sign in to your Alces Flight account please enter your password.\n", '#2794d8']
-                       args[0]
-                     end
+            prompt.say Paint["To sign in to your Alces Flight account please enter your username/email \nand password.\n", '#2794d8']
+            prompt.ask('Username/Email:', default: Config.username)
+          else
+            prompt.say Paint["To sign in to your Alces Flight account please enter your password.\n", '#2794d8']
+            args[0]
+          end
           password = prompt.mask('Password:')
 
           login = nil


### PR DESCRIPTION
Relatively small changes to allow the user to login via `email` as well as `username`. The cached username is now retrieved from the SSO response instead of the user input.